### PR TITLE
Add googlemapfield class name so JS actually binds to the fields

### DIFF
--- a/client/js/GoogleMapField.js
+++ b/client/js/GoogleMapField.js
@@ -232,7 +232,7 @@ window.googlemapfieldInit = function () {
     };
 
     function init() {
-        var mapFields = $(".googlemapfield:visible").gmapfield();
+        var mapFields = $(".googlemapfield").gmapfield();
 
         mapFields.each(initField);
     }

--- a/src/GoogleMapField.php
+++ b/src/GoogleMapField.php
@@ -79,6 +79,8 @@ class GoogleMapField extends CompositeField
             $this->defaultValues = $data;
         }
 
+        $this->addExtraClass('googlemapfield');
+
         $this->setupChildren();
 
     }

--- a/src/GoogleMapField.php
+++ b/src/GoogleMapField.php
@@ -102,9 +102,9 @@ class GoogleMapField extends CompositeField
 
     public function setValue($value, $data = null)
     {
-        if ($data) {
-            $this->setDataRecord($data);
-        } else if (!$this->children->count()) {
+        $this->setDataRecord($value);
+
+        if (!$this->children->count()) {
             $this->setupChildren();
         }
 

--- a/templates/BetterBrief/GoogleMapField_holder.ss
+++ b/templates/BetterBrief/GoogleMapField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="field<% if $extraClass %> $extraClass<% end_if %>">
+<div id="$HolderID" class="field">
 	<% if $Title %><label class="left" for="$ID">$Title</label><% end_if %>
 	<div class="middleColumn">
 		$Field


### PR DESCRIPTION
Not sure if this is just my implementation, but this module doesn't work out of the box with SS5 without the following:
- Add 'googlemapfield' class to the field (and not to the fieldholder)
- Remove `:visible` psuedo-class trigger as the Google Maps callback function often triggers before the page is rendered (meaning the field is sometimes not yet visible as the HTML isn't rendered).
- Only push the data for the specific field through when calling `->setValue()` (see below).

This does remove `extraClasses` from the holder template, not sure if this is a bad idea or not really - but the JS breaks without this as multiple elements match the `.googlemapfield` selector but only the inner field has the relevant `data-` attributes.

Test case for the 3rd change:
1. Submit the form normally, see that all data processes fine.
2. Submit the form again, but this time miss a different required field with JS disabled.
3. This results in a server validation message for the other field, and results in the map not loading correctly (what actually happens is the `data-options` attribute contains coordinates of `[null, null]` which GMaps doesn't parse, so a map isn't displayed).

With this fix in place, data is saved and restored correctly when validation errors on other fields occur, and submission still works fine.